### PR TITLE
Make the plugin works with Grails 2.4.3

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -28,7 +28,7 @@ grails.project.dependency.resolution = {
            export = false
         }
 
-        runtime ":jquery:1.8.3"
-        runtime ":resources:1.2.1"
+        runtime ":jquery:1.11.1"
+        runtime ":resources:1.2.14"
     }
 }

--- a/grails-app/conf/filters/PjaxFilters.groovy
+++ b/grails-app/conf/filters/PjaxFilters.groovy
@@ -1,4 +1,4 @@
-
+package filters
 class PjaxFilters {
 
     def filters = {


### PR DESCRIPTION
I'm using Grails 2.4.3 and wanted to use pjax, and i found this plugin.
However, when i encounter compile error with the Resources plugin, thus i upgrade Resources to 1.2.14.
After this, i encounter another error cannot find class "filters.PjaxFilters" , so i added the package.
